### PR TITLE
Add README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build package
+        uses: sersoft-gmbh/xcodebuild-action@v3
+        with:
+          spm-package: './'
+          scheme: BroadcastUploadExtensionHelper
+          destination: 'generic/platform=iOS'
+          action: build
+          output-formatter: xcbeautify

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:6.1
+import PackageDescription
+
+let package = Package(
+    name: "BroadcastUploadExtensionHelper",
+    platforms: [
+        .iOS(.v16)
+    ],
+    products: [
+        .library(name: "BroadcastUploadExtension", targets: ["BroadcastUploadExtension"])
+    ],
+    targets: [
+        .target(
+            name: "BroadcastHelper",
+            publicHeadersPath: "include"
+        ),
+        .target(
+            name: "BroadcastUploadExtension",
+            dependencies: ["BroadcastHelper"]
+        ),
+        .testTarget(
+            name: "BroadcastUploadExtensionHelperTests",
+            dependencies: ["BroadcastUploadExtension"]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# BroadcastUploadExtensionHelper
+
+A Swift package that wraps an Objective-C helper for ReplayKit Broadcast Upload Extensions. It allows you to finish broadcasts gracefully without showing an error or to present a custom error message.
+
+## Usage
+
+Add the package through Swift Package Manager using this repository's URL. Import `BroadcastUploadExtension` in your extension target:
+
+```swift
+import BroadcastUploadExtension
+```
+
+From your `RPBroadcastSampleHandler` subclass you can end the broadcast:
+
+```swift
+finishGracefully()                   // End normally
+finishWithError(message: "Oops")     // End with an error alert
+```
+
+`finishGracefully()` invokes the Objective-C helper to end without an alert.

--- a/Sources/BroadcastHelper/BroadcastUploadHelper.h
+++ b/Sources/BroadcastHelper/BroadcastUploadHelper.h
@@ -1,0 +1,3 @@
+#import <ReplayKit/ReplayKit.h>
+
+void finishBroadcastGracefully(RPBroadcastSampleHandler * _Nonnull broadcastSampleHandler);

--- a/Sources/BroadcastHelper/BroadcastUploadHelper.m
+++ b/Sources/BroadcastHelper/BroadcastUploadHelper.m
@@ -1,0 +1,8 @@
+#import "BroadcastUploadHelper.h"
+
+void finishBroadcastGracefully(RPBroadcastSampleHandler * _Nonnull broadcastSampleHandler) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    [broadcastSampleHandler finishBroadcastWithError:nil];
+#pragma clang diagnostic pop
+}

--- a/Sources/BroadcastHelper/include/BroadcastHelper.h
+++ b/Sources/BroadcastHelper/include/BroadcastHelper.h
@@ -1,0 +1,6 @@
+#ifndef BroadcastHelper_h
+#define BroadcastHelper_h
+
+#import "../BroadcastUploadHelper.h"
+
+#endif

--- a/Sources/BroadcastUploadExtension/RPBroadcastSampleHandler+Extension.swift
+++ b/Sources/BroadcastUploadExtension/RPBroadcastSampleHandler+Extension.swift
@@ -1,0 +1,35 @@
+import BroadcastHelper
+import ReplayKit
+
+extension RPBroadcastSampleHandler {
+  /// Gracefully ends the current broadcast session without displaying an error to the user.
+  /// Use this method when terminating the broadcast due to normal conditions
+  /// (e.g., user requested stop, successful completion).
+  ///
+  /// - Note: This uses the system's graceful termination method rather than showing an error.
+  public func finishGracefully() {
+    finishBroadcastGracefully(self)
+  }
+
+  /// Terminates the broadcast session and displays the provided error message to the user.
+  /// Use this method when the broadcast needs to be stopped due to an error condition
+  /// (e.g., insufficient resources, invalid configuration).
+  ///
+  /// - Parameter message: A user-friendly error message explaining why the broadcast ended
+  /// - Note: This will present the error message in a system alert to the user
+  public func finishWithError(message: String) {
+    let errorDomain = "com.yourapp.BroadcastExtension.Error"
+    let userInfo: [String: Any] = [
+      NSLocalizedFailureReasonErrorKey: message,
+      NSLocalizedDescriptionKey: "Broadcast session terminated",
+    ]
+
+    let error = NSError(
+      domain: errorDomain,
+      code: 1001,  // Custom error code for broadcast termination
+      userInfo: userInfo
+    )
+
+    finishBroadcastWithError(error)
+  }
+}

--- a/Tests/BroadcastUploadExtensionHelperTests/PlaceholderTests.swift
+++ b/Tests/BroadcastUploadExtensionHelperTests/PlaceholderTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import BroadcastUploadExtension
+
+final class PlaceholderTests: XCTestCase {
+    func testExample() {
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
## Summary
- document the BroadcastUploadExtensionHelper package with a short README

## Testing
- `swift --version`
- `swift build -c release` *(fails: `'ReplayKit/ReplayKit.h' file not found`)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684947cfe4d0832c9ab867ba63c12bdf